### PR TITLE
chef rest update

### DIFF
--- a/lib/chef/knife/goiardi_job_cancel.rb
+++ b/lib/chef/knife/goiardi_job_cancel.rb
@@ -36,7 +36,6 @@ class Chef
 	  exit 1
 	end
 	@node_names = name_args[1, name_args.length - 1]
-	rest = Chef::REST.new(Chef::Config[:chef_server_url])
 	cancel_json = {
 	  'run_id' => job_id,
 	  'nodes' => @node_names

--- a/lib/chef/knife/goiardi_job_cancel.rb
+++ b/lib/chef/knife/goiardi_job_cancel.rb
@@ -19,9 +19,6 @@
 class Chef
   class Knife
     class GoiardiJobCancel < Chef::Knife
-      deps do
-        require 'chef/rest'
-      end
       banner "knife goiardi job cancel <job id> [<node> <node> ...]"
 
       option :kill_timeout,

--- a/lib/chef/knife/goiardi_job_cancel.rb
+++ b/lib/chef/knife/goiardi_job_cancel.rb
@@ -20,39 +20,39 @@ class Chef
   class Knife
     class GoiardiJobCancel < Chef::Knife
       deps do
-	require 'chef/rest'
+        require 'chef/rest'
       end
       banner "knife goiardi job cancel <job id> [<node> <node> ...]"
 
       option :kill_timeout,
-	:long => '--kill-timeout TIMEOUT',
-	:description => "Amount of time to wait, in seconds, to stop a job before it's forcefully killed"
+        :long => '--kill-timeout TIMEOUT',
+        :description => "Amount of time to wait, in seconds, to stop a job before it's forcefully killed"
 
       def run
-	job_id = @name_args[0]
-	if job_id.nil?
-	  ui.error "No job id specified"
-	  show_usage
-	  exit 1
-	end
-	@node_names = name_args[1, name_args.length - 1]
-	cancel_json = {
-	  'run_id' => job_id,
-	  'nodes' => @node_names
-	}
-	if config[:kill_timeout]
-	  cancel_json['kill_timeout'] = config[:kill_timeout]
-	end
-	result = rest.put_rest('shovey/jobs/cancel', cancel_json)
-	# wait to figure out what to do with the reply until I've confirmed that
-	# it works on the goiardi end
-	cancel_output = {
-	  "command" => result["command"],
-	  "id" => result["id"],
-	  "status" => result["status"],
-	  "cancelled nodes" => result["nodes"]["cancelled"]
-	}
-	output(cancel_output)
+        job_id = @name_args[0]
+        if job_id.nil?
+          ui.error "No job id specified"
+          show_usage
+          exit 1
+        end
+        @node_names = name_args[1, name_args.length - 1]
+        cancel_json = {
+          'run_id' => job_id,
+          'nodes' => @node_names
+        }
+        if config[:kill_timeout]
+          cancel_json['kill_timeout'] = config[:kill_timeout]
+        end
+        result = rest.put_rest('shovey/jobs/cancel', cancel_json)
+        # wait to figure out what to do with the reply until I've confirmed that
+        # it works on the goiardi end
+        cancel_output = {
+          "command" => result["command"],
+          "id" => result["id"],
+          "status" => result["status"],
+          "cancelled nodes" => result["nodes"]["cancelled"]
+        }
+        output(cancel_output)
       end
 
     end

--- a/lib/chef/knife/goiardi_job_info.rb
+++ b/lib/chef/knife/goiardi_job_info.rb
@@ -20,25 +20,25 @@ class Chef
   class Knife
     class GoiardiJobInfo < Chef::Knife
       deps do
-	require 'chef/rest'
+        require 'chef/rest'
       end
       banner "knife goiardi job info <job id> <node>"
 
       def run
-	job_id = @name_args[0]
-	if job_id.nil?
-	  ui.error "No job id specified"
-	  show_usage
-	  exit 1
-	end
-	node = @name_args[1]
-	if node.nil?
-	  ui.error "No node specified"
-	  show_usage
-	  exit 1
-	end
-	info = rest.get_rest("shovey/jobs/#{job_id}/#{node}")
-	output(info)
+        job_id = @name_args[0]
+        if job_id.nil?
+          ui.error "No job id specified"
+          show_usage
+          exit 1
+        end
+        node = @name_args[1]
+        if node.nil?
+          ui.error "No node specified"
+          show_usage
+          exit 1
+        end
+        info = rest.get_rest("shovey/jobs/#{job_id}/#{node}")
+        output(info)
       end
     end
   end

--- a/lib/chef/knife/goiardi_job_info.rb
+++ b/lib/chef/knife/goiardi_job_info.rb
@@ -19,9 +19,6 @@
 class Chef
   class Knife
     class GoiardiJobInfo < Chef::Knife
-      deps do
-        require 'chef/rest'
-      end
       banner "knife goiardi job info <job id> <node>"
 
       def run

--- a/lib/chef/knife/goiardi_job_info.rb
+++ b/lib/chef/knife/goiardi_job_info.rb
@@ -37,7 +37,6 @@ class Chef
 	  show_usage
 	  exit 1
 	end
-	rest = Chef::REST.new(Chef::Config[:chef_server_url])
 	info = rest.get_rest("shovey/jobs/#{job_id}/#{node}")
 	output(info)
       end

--- a/lib/chef/knife/goiardi_job_list.rb
+++ b/lib/chef/knife/goiardi_job_list.rb
@@ -21,8 +21,6 @@ class Chef
       banner "knife goiardi job list"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         jobs = rest.get_rest("shovey/jobs")
         output(jobs)
       end

--- a/lib/chef/knife/goiardi_job_start.rb
+++ b/lib/chef/knife/goiardi_job_start.rb
@@ -32,23 +32,23 @@ class Chef
         :description => "Maximum time the job will be allowed to run (in seconds)."
 
       option :quorum,
-            :short => '-q QUORUM',
-            :long => '--quorum QUORUM',
-            :default => '100%',
-            :description => 'Shovey job quorum. Percentage (-q 50%) or Count (-q 145).'
+        :short => '-q QUORUM',
+        :long => '--quorum QUORUM',
+        :default => '100%',
+        :description => 'Shovey job quorum. Percentage (-q 50%) or Count (-q 145).'
 
       option :search,
-            :short => '-s QUERY',
-            :long => '--search QUERY',
-            :required => false,
-            :description => 'Solr query for list of job candidates.'
+        :short => '-s QUERY',
+        :long => '--search QUERY',
+        :required => false,
+        :description => 'Solr query for list of job candidates.'
 
       option :nowait,
-	    :long => '--dont-wait',
-	    :short => '-b',
-	    :boolean => true,
-	    :default => false,
-	    :description => "Rather than waiting for each job to complete, exit immediately after starting the job."
+        :long => '--dont-wait',
+        :short => '-b',
+        :boolean => true,
+        :default => false,
+        :description => "Rather than waiting for each job to complete, exit immediately after starting the job."
 
       def run
         @node_names = []
@@ -63,7 +63,7 @@ class Chef
         if config[:search]
           q = Chef::Search::Query.new
           @escaped_query = URI.escape(config[:search],
-                                     Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+                                      Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
           begin
             nodes = q.search(:node, @escaped_query).first
           rescue Net::HTTPServerException => e
@@ -92,7 +92,7 @@ class Chef
         result = rest.post_rest('shovey/jobs', job_json)
         job_uri = result['uri']
         puts "Started.  Job ID: #{job_uri[-36,36]}"
-	exit(0) if config[:nowait]
+        exit(0) if config[:nowait]
         previous_state = "Initialized."
         begin
           sleep(0.1)
@@ -139,18 +139,18 @@ class Chef
         num = qmatch[1]
 
         case qmatch[2]
-          when "%" then
-            ((num.to_f/100)*total_nodes).ceil
-          else
-            num.to_i
+        when "%" then
+          ((num.to_f/100)*total_nodes).ceil
+        else
+          num.to_i
         end
       end
 
       def status_code(job)
         if job['status'] == "complete" && job["nodes"].keys.all? do |key|
-            key == "succeeded" || key == "nacked" || key == "unavailable"
-          end
-          0
+          key == "succeeded" || key == "nacked" || key == "unavailable"
+        end
+        0
         else
           1
         end

--- a/lib/chef/knife/goiardi_job_start.rb
+++ b/lib/chef/knife/goiardi_job_start.rb
@@ -76,12 +76,12 @@ class Chef
           @node_names = name_args[1,name_args.length-1]
         end
 
+        puts @node_names.inspect
+
         if @node_names.empty?
           ui.error "No nodes to run job on. Specify nodes as arguments or use -s to specify a search query."
           exit 1
         end
-
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
 
         job_json = {
           'command' => job_name,

--- a/lib/chef/knife/goiardi_job_start.rb
+++ b/lib/chef/knife/goiardi_job_start.rb
@@ -20,7 +20,6 @@ class Chef
     class GoiardiJobStart < Chef::Knife
 
       deps do
-        require 'chef/rest'
         require 'chef/node'
         require 'chef/search/query'
       end
@@ -75,8 +74,6 @@ class Chef
         else
           @node_names = name_args[1,name_args.length-1]
         end
-
-        puts @node_names.inspect
 
         if @node_names.empty?
           ui.error "No nodes to run job on. Specify nodes as arguments or use -s to specify a search query."

--- a/lib/chef/knife/goiardi_job_status.rb
+++ b/lib/chef/knife/goiardi_job_status.rb
@@ -21,8 +21,6 @@ class Chef
       banner "knife goiardi job status <job id>"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         job_id = name_args[0]
         job = rest.get_rest("shovey/jobs/#{job_id}")
         output(job)

--- a/lib/chef/knife/goiardi_job_stream.rb
+++ b/lib/chef/knife/goiardi_job_stream.rb
@@ -37,7 +37,6 @@ class Chef
 	  show_usage
 	  exit 1
 	end
-	rest = Chef::REST.new(Chef::Config[:chef_server_url])
 	outseq = 0
 	errseq = 0
 	outdone = false

--- a/lib/chef/knife/goiardi_job_stream.rb
+++ b/lib/chef/knife/goiardi_job_stream.rb
@@ -19,9 +19,6 @@
 class Chef
   class Knife
     class GoiardiJobStream < Chef::Knife
-      deps do
-        require 'chef/rest'
-      end
       banner "knife goiardi job stream <job id> <node>"
 
       def run

--- a/lib/chef/knife/goiardi_job_stream.rb
+++ b/lib/chef/knife/goiardi_job_stream.rb
@@ -20,57 +20,57 @@ class Chef
   class Knife
     class GoiardiJobStream < Chef::Knife
       deps do
-	require 'chef/rest'
+        require 'chef/rest'
       end
       banner "knife goiardi job stream <job id> <node>"
 
       def run
-	job_id = @name_args[0]
-	if job_id.nil?
-	  ui.error "No job id specified"
-	  show_usage
-	  exit 1
-	end
-	node_name = @name_args[1]
-	if node_name.nil?
-	  ui.error "No node specified"
-	  show_usage
-	  exit 1
-	end
-	outseq = 0
-	errseq = 0
-	outdone = false
-	errdone = false
-	loop do
-	  if !outdone
-	    outres = rest.get_rest("shovey/stream/#{job_id}/#{node_name}?sequence=#{outseq}&output_type=stdout")
-	    if !outres["last_seq"].nil?
-	      seq = outres["last_seq"] + 1
-	    end
-	    if outres["output"] != ""
-	      stdout.print(outres["output"])
-	    end
-	    if outres["is_last"]
-	      outdone = true
-	    end
-	  end
-	  if !errdone
-	    errres = rest.get_rest("shovey/stream/#{job_id}/#{node_name}?sequence=#{errseq}&output_type=stderr")
-	    if !errres["last_seq"].nil?
-	      seq = errres["last_seq"] + 1
-	    end
-	    if errres["output"] != ""
-	      stderr.print(ui.color(errres["output"], :red))
-	    end
-	    if errres["is_last"]
-	      errdone = true
-	    end
-	  end
-	  break if outdone && errdone
-	  sleep 0.25
-	end
-	ui.msg(ui.color("\nDone!", :blue))
-	ui.pretty_print("\nFinished streaming output for job #{job_id} on node #{node_name}")
+        job_id = @name_args[0]
+        if job_id.nil?
+          ui.error "No job id specified"
+          show_usage
+          exit 1
+        end
+        node_name = @name_args[1]
+        if node_name.nil?
+          ui.error "No node specified"
+          show_usage
+          exit 1
+        end
+        outseq = 0
+        errseq = 0
+        outdone = false
+        errdone = false
+        loop do
+          if !outdone
+            outres = rest.get_rest("shovey/stream/#{job_id}/#{node_name}?sequence=#{outseq}&output_type=stdout")
+            if !outres["last_seq"].nil?
+              seq = outres["last_seq"] + 1
+            end
+            if outres["output"] != ""
+              stdout.print(outres["output"])
+            end
+            if outres["is_last"]
+              outdone = true
+            end
+          end
+          if !errdone
+            errres = rest.get_rest("shovey/stream/#{job_id}/#{node_name}?sequence=#{errseq}&output_type=stderr")
+            if !errres["last_seq"].nil?
+              seq = errres["last_seq"] + 1
+            end
+            if errres["output"] != ""
+              stderr.print(ui.color(errres["output"], :red))
+            end
+            if errres["is_last"]
+              errdone = true
+            end
+          end
+          break if outdone && errdone
+          sleep 0.25
+        end
+        ui.msg(ui.color("\nDone!", :blue))
+        ui.pretty_print("\nFinished streaming output for job #{job_id} on node #{node_name}")
       end
     end
   end

--- a/lib/chef/knife/goiardi_node_status.rb
+++ b/lib/chef/knife/goiardi_node_status.rb
@@ -21,8 +21,6 @@ class Chef
       banner "knife goiardi node status [<node> <node> ...]"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         get_node_statuses(name_args).each do |node_status|
           puts "#{node_status['node_name']}\t#{node_status['status']}"
         end


### PR DESCRIPTION
`Chef::REST` was deprecated in Chef 12 https://docs.chef.io/deprecations_chef_rest.html

These commits remove Chef::REST and use the implementation of choice provided by `Chef::Knife` as `rest`

Chef 11 https://github.com/chef/chef/blob/11.18.0.r/lib/chef/knife.rb#L537
Chef 13 https://github.com/chef/chef/blob/v13.1.15/lib/chef/knife.rb#L588

tested with knife from a  chef12-chefdk and chef13-chefdk
